### PR TITLE
Improve setup and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ cp -r dist/* ../backend/src/main/resources/static/
 - Open browser: `http://192.168.x.x:8080`
 - Input your coordinates and start tracking!
 
+For a step-by-step installation walkthrough see **docs/setup.md**. To run the
+app automatically on boot refer to **docs/deploy.md**.
+
 ## 🌍 Core Features
 
 ### Location Management
@@ -181,9 +184,9 @@ launch-calculator/
 │   ├── package.json
 │   └── public/
 ├── docs/
-│   ├── api.md
 │   ├── setup.md
-│   └── troubleshooting.md
+│   ├── deploy.md
+│   └── (additional docs)
 └── scripts/
     ├── deploy.sh
     └── update-tle.sh

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,61 @@
+# Deployment Guide
+
+This document explains how to run Launch Calculator as a long‑running service on your Raspberry Pi once you have completed the steps in `setup.md`.
+
+## 1. Build Application Artifacts
+
+From the project root run the deployment script which compiles the backend and bundles the frontend:
+```bash
+./scripts/deploy.sh
+```
+
+After it finishes you should have a JAR file at `backend/target/launch-calculator-0.1.jar` and the frontend assets copied into `backend/src/main/resources/static/`.
+
+## 2. Starting Manually
+
+Test that the application starts correctly:
+```bash
+java -Xmx256m -jar backend/target/launch-calculator-0.1.jar
+```
+
+Open `http://<pi-address>:8080` in your browser. Press `Ctrl+C` to stop the server.
+
+## 3. Running as a systemd Service
+
+To keep the application running after reboot, create a systemd unit. Replace `/home/pi/launch-calculator` with the path to your cloned repository if different.
+
+Create `/etc/systemd/system/launch-calculator.service` with the following contents:
+```ini
+[Unit]
+Description=Launch Calculator Service
+After=network.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/launch-calculator
+ExecStart=/usr/bin/java -Xmx256m -jar /home/pi/launch-calculator/backend/target/launch-calculator-0.1.jar
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+Then enable and start the service:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now launch-calculator
+```
+The application will now start automatically on boot and can be reached at `http://<pi-address>:8080`.
+
+## 4. Updating Satellite Data
+
+Periodically refresh the TLE data using:
+```bash
+./scripts/update-tle.sh
+```
+Run this while connected to the internet, then restart the service if needed:
+```bash
+sudo systemctl restart launch-calculator
+```
+
+You now have a fully deployed Launch Calculator that will survive reboots.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,24 +1,74 @@
 # Setup Guide
 
-Follow these steps to run Launch Calculator on a Raspberry Pi Zero W.
+This guide walks you through preparing a Raspberry Pi Zero W and installing **Launch Calculator** from scratch. No prior environment is assumed.
 
-1. Install Java, Node.js and Git as shown in the README.
-2. Build the backend (while online once):
+## 1. Prepare the Raspberry Pi
+
+1. Download the latest **Raspberry Pi OS Lite** image from the official website.
+2. Flash the image to a microSD card using **Raspberry Pi Imager** or `dd` on Linux/Mac.
+3. (Optional) To enable headless access, create an empty file named `ssh` in the boot partition and add a `wpa_supplicant.conf` file with your Wi‑Fi credentials.
+4. Insert the card into the Pi Zero W and power it on.
+
+## 2. First Boot Configuration
+
+1. Connect to the Pi via SSH or a keyboard and monitor.
+2. Run the initial update and install required packages:
    ```bash
-   cd backend
-   ./mvnw dependency:go-offline
-   ./mvnw -o package
-   java -jar target/launch-calculator-0.1.0.jar
+   sudo apt update && sudo apt upgrade -y
+   sudo apt install openjdk-11-jdk maven nodejs npm git -y
    ```
-3. Build the frontend (after dependencies have been installed once):
+3. Verify the installations:
    ```bash
-   cd ../frontend
-   npm install
-   npm run build
-   cp dist/* ../backend/src/main/resources/static/
+   java -version   # should print an OpenJDK 11 version
+   mvn -version    # should print the Maven version
+   node -v         # should print the Node.js version
    ```
-4. (Optional) Update TLE data while online:
+
+## 3. Clone the Repository
+
+1. Choose a directory (e.g. `/home/pi`) and clone the project:
    ```bash
-   ./scripts/update-tle.sh
+   git clone https://github.com/youruser/launch-calculator.git
+   cd launch-calculator
    ```
-5. Access the app at `http://<pi-address>:8080`.
+
+## 4. Build the Backend
+
+While online, download dependencies and package the application:
+```bash
+cd backend
+mvn dependency:go-offline      # fetch Maven dependencies once
+mvn -o clean package           # build using the cached dependencies
+```
+
+The compiled JAR will appear under `backend/target/`.
+
+## 5. Build the Frontend
+
+```bash
+cd ../frontend
+npm install              # install Node modules
+npm run build            # create production bundle
+cp -r dist/* ../backend/src/main/resources/static/
+```
+
+This copies the built web assets so the Spring Boot app can serve them.
+
+## 6. Test the Application
+
+Start the backend on the Pi:
+```bash
+cd ../backend
+java -Xmx256m -jar target/launch-calculator-0.1.jar
+```
+
+Browse to `http://<pi-address>:8080` from another device on the network. You should see the application UI.
+
+## 7. Updating TLE Data
+
+When you have internet connectivity, run the provided script to refresh satellite data:
+```bash
+./scripts/update-tle.sh
+```
+
+You are now ready to deploy the application permanently. See `docs/deploy.md` for details on running Launch Calculator as a service.


### PR DESCRIPTION
## Summary
- expand `docs/setup.md` with step-by-step instructions
- add new `docs/deploy.md` describing service deployment
- reference new docs from README and update directory listing

## Testing
- `npm --prefix frontend run build` *(fails: Could not find a declaration file for module 'react-dom')*
- `mvn -f backend/pom.xml -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a960560ec832bb09ca12d50570aa0