### PR TITLE
Add Docker usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ cp -r dist/* ../backend/src/main/resources/static/
 
 For a step-by-step installation walkthrough see **docs/setup.md**. To run the
 app automatically on boot refer to **docs/deploy.md**.
-=======
 ### 5. Build and Run with Docker
 An alternative to installing the toolchain locally is to use Docker. The
 provided `Dockerfile` bundles the backend and frontend into a single image.
@@ -128,6 +127,7 @@ docker build -t launch-calculator .
 # Run the application
 docker run -p 8080:8080 launch-calculator
 ```
+See **docs/docker.md** for detailed Docker instructions.
 
 ## 🌍 Core Features
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,35 @@
+# Docker Usage Guide
+
+This guide covers how to build and run the Launch Calculator Docker image and outlines the project layout for development.
+
+## Building the Image
+
+Run the following command from the project root:
+```bash
+docker build -t launch-calculator .
+```
+This compiles the frontend and backend and packages them into a single image.
+
+## Running the Container
+
+Start the application on port 8080:
+```bash
+docker run -p 8080:8080 launch-calculator
+```
+Then open `http://localhost:8080` in your browser.
+
+To persist satellite data between runs, mount the `data/tle` directory:
+```bash
+docker run -p 8080:8080 -v $(pwd)/data/tle:/app/data/tle launch-calculator
+```
+
+## Repository Layout
+
+- `backend/`   – Spring Boot application
+- `frontend/`  – React client
+- `scripts/`   – Helper scripts (`deploy.sh`, `update-tle.sh`)
+- `docs/`      – Documentation
+
+Use `scripts/deploy.sh` to build the JAR and bundle the frontend without Docker.
+Update TLE data with `scripts/update-tle.sh` when online.
+


### PR DESCRIPTION
## Summary
- add `docs/docker.md` with instructions for building and running the container
- link to the new doc from the README and remove merge marker

## Testing
- `mvn -f backend/pom.xml -q package -DskipTests` *(fails: Could not download dependencies)*
- `npm --prefix frontend install`
- `npm --prefix frontend run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_687aa45f5a20832b93ffe1f9d7d3a866