### PR TITLE
Add env-based Cesium token

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,14 +257,13 @@ visibility.elevation.minimum=10
 ```
 
 ### Frontend Configuration
-```typescript
-// src/config/app.ts
-export const APP_CONFIG = {
-  API_BASE_URL: process.env.REACT_APP_API_URL || '/api',
-  CESIUM_ION_TOKEN: 'your-cesium-token',
-  UPDATE_INTERVAL: 30000, // 30 seconds
-  DEFAULT_LOCATION: { lat: 39.7392, lon: -104.9903 }, // Denver
-};
+The Cesium ion access token is provided via the `CESIUM_ION_TOKEN` environment
+variable. Set this before starting the backend so the frontend can load the
+token dynamically:
+
+```bash
+export CESIUM_ION_TOKEN=your-cesium-token
+java -jar backend/target/launch-calculator-0.1.jar
 ```
 
 ## 🔍 Usage Examples

--- a/backend/src/main/java/com/calculator/controller/ConfigController.java
+++ b/backend/src/main/java/com/calculator/controller/ConfigController.java
@@ -1,0 +1,17 @@
+package com.calculator.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ConfigController {
+
+    @Value("${cesium.ion.token:}")
+    private String cesiumIonToken;
+
+    @GetMapping("/api/config/cesium-token")
+    public String getCesiumIonToken() {
+        return cesiumIonToken;
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 server.port=8080
 server.servlet.context-path=/
 # TLE update interval not used in simple example
+# Cesium ion token (override with CESIUM_ION_TOKEN env var)
+cesium.ion.token=

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,16 +1,28 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { Viewer } from 'cesium';
+import { Viewer, Ion } from 'cesium';
 import axios from 'axios';
 
 const App = () => {
   React.useEffect(() => {
-    const viewer = new Viewer('cesiumContainer');
-    navigator.geolocation.getCurrentPosition(async (pos) => {
-      const { latitude, longitude } = pos.coords;
-      const resp = await axios.get(`/api/satellites/visible?lat=${latitude}&lon=${longitude}`);
-      console.log('Visible', resp.data);
-    });
+    const init = async () => {
+      try {
+        const { data: token } = await axios.get('/api/config/cesium-token');
+        if (token) {
+          Ion.defaultAccessToken = token;
+        }
+      } catch (e) {
+        console.error('Failed to load Cesium token', e);
+      }
+
+      const viewer = new Viewer('cesiumContainer');
+      navigator.geolocation.getCurrentPosition(async (pos) => {
+        const { latitude, longitude } = pos.coords;
+        const resp = await axios.get(`/api/satellites/visible?lat=${latitude}&lon=${longitude}`);
+        console.log('Visible', resp.data);
+      });
+    };
+    init();
   }, []);
   return <div id="cesiumContainer" style={{height: '100vh'}}></div>;
 };


### PR DESCRIPTION
## Summary
- fetch Cesium ion token from backend
- read token from `CESIUM_ION_TOKEN` environment variable
- document new environment variable usage

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ac71d2bd8832bbde3daf2a1056a4b