### PR TITLE
Add AstroSolver dependency engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ docker run -p 8080:8080 launch-calculator
 ```
 See **docs/docker.md** for detailed Docker instructions.
 
+### 5. Run AstroSolver on the Command Line
+```bash
+python -m app --cli --r "7000,0,0" --v "0,7.5,1"
+```
+The CLI resolves all possible orbital parameters from the provided vectors and
+prints how each value was derived.
+
 ## 🌍 Core Features
 
 ### Location Management

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,4 +1,38 @@
+import argparse
+import numpy as np
 from . import app
+from .astrosolver import AstroSolver
+
+
+def parse_vector(text):
+    values = [float(x) for x in text.split(',') if x]
+    return np.array(values)
+
+
+def run_cli(args):
+    solver = AstroSolver(mu=args.mu)
+    knowns = {}
+    if args.r:
+        knowns['r'] = parse_vector(args.r)
+    if args.v:
+        knowns['v'] = parse_vector(args.v)
+    kb = solver.solve(**knowns)
+    print(kb.explain())
+
+
+def main():
+    parser = argparse.ArgumentParser(description="AstroSolver Toolkit")
+    parser.add_argument('--cli', action='store_true', help='Run CLI instead of web')
+    parser.add_argument('--r', help='Position vector components comma separated')
+    parser.add_argument('--v', help='Velocity vector components comma separated')
+    parser.add_argument('--mu', type=float, default=398600.4418, help='Gravitational parameter')
+    args = parser.parse_args()
+
+    if args.cli:
+        run_cli(args)
+    else:
+        app.run(host='0.0.0.0', port=8080)
+
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=8080)
+    main()

--- a/app/astrosolver.py
+++ b/app/astrosolver.py
@@ -1,0 +1,89 @@
+import numpy as np
+from dataclasses import dataclass, field
+from math import pi, sqrt
+
+@dataclass
+class KnowledgeBase:
+    data: dict = field(default_factory=dict)
+    derivations: dict = field(default_factory=dict)
+
+    def add(self, key, value, derivation="provided"):
+        if key not in self.data:
+            self.data[key] = value
+            self.derivations[key] = derivation
+
+    def has(self, key):
+        return key in self.data
+
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+    def explain(self):
+        lines = []
+        for k, v in self.data.items():
+            deriv = self.derivations.get(k, "")
+            lines.append(f"{k}: {v} ({deriv})")
+        return "\n".join(lines)
+
+class Calculation:
+    def __init__(self, required, outputs, func):
+        self.required = required
+        self.outputs = outputs
+        self.func = func
+
+    def can_run(self, kb):
+        return all(kb.has(r) for r in self.required)
+
+    def run(self, kb):
+        results = self.func(*[kb.get(r) for r in self.required])
+        if len(self.outputs) == 1:
+            results = (results,)
+        for out, res in zip(self.outputs, results):
+            kb.add(out, res, f"from {', '.join(self.required)} via {self.func.__name__}")
+
+class AstroSolver:
+    def __init__(self, mu=398600.4418):
+        self.mu = mu
+        self.calculations = []
+        self._build_calculations()
+
+    def add_calculation(self, required, outputs, func):
+        self.calculations.append(Calculation(required, outputs, func))
+
+    def _build_calculations(self):
+        self.add_calculation(['r'], ['r_mag'], lambda r: np.linalg.norm(r))
+        self.add_calculation(['v'], ['v_mag'], lambda v: np.linalg.norm(v))
+        self.add_calculation(['r', 'v'], ['h_vec'], lambda r, v: np.cross(r, v))
+        self.add_calculation(['h_vec'], ['h_mag'], lambda h: np.linalg.norm(h))
+        self.add_calculation(['v_mag', 'r_mag'], ['specific_energy'],
+                             lambda v_mag, r_mag: v_mag ** 2 / 2 - self.mu / r_mag)
+        self.add_calculation(['specific_energy'], ['semi_major_axis'],
+                             lambda energy: -self.mu / (2 * energy))
+        self.add_calculation(['r', 'v'], ['eccentricity_vec'],
+                             lambda r, v: np.cross(v, np.cross(r, v)) / self.mu - r / np.linalg.norm(r))
+        self.add_calculation(['eccentricity_vec'], ['eccentricity'],
+                             lambda e_vec: np.linalg.norm(e_vec))
+        self.add_calculation(['eccentricity'], ['orbit_type'], self.classify_orbit)
+        self.add_calculation(['semi_major_axis'], ['period'],
+                             lambda a: 2 * pi * sqrt(a ** 3 / self.mu) if a > 0 else None)
+
+    def classify_orbit(self, e):
+        if e < 1:
+            return 'elliptical'
+        elif np.isclose(e, 1.0):
+            return 'parabolic'
+        else:
+            return 'hyperbolic'
+
+    def solve(self, **knowns):
+        kb = KnowledgeBase()
+        for k, v in knowns.items():
+            kb.add(k, v)
+        progress = True
+        while progress:
+            progress = False
+            for calc in self.calculations:
+                if calc.can_run(kb) and not all(kb.has(o) for o in calc.outputs):
+                    calc.run(kb)
+                    progress = True
+        return kb

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -23,6 +23,12 @@ To persist satellite data between runs, mount the `data/tle` directory:
 docker run -p 8080:8080 -v $(pwd)/data/tle:/app/data/tle launch-calculator
 ```
 
+### CLI Usage
+You can also run AstroSolver directly inside the container:
+```bash
+docker run --rm launch-calculator python -m app --cli --r "7000,0,0" --v "0,7.5,1"
+```
+
 ## Repository Layout
 
 - `app/`       – Flask application

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 pyorbital
+numpy


### PR DESCRIPTION
## Summary
- add AstroSolver module with chained dependency engine to derive orbital parameters
- extend CLI in `__main__` to run the solver
- document CLI usage in README and Docker instructions
- add numpy dependency

## Testing
- `python -m pip install -r requirements.txt`
- `python -m app --cli --r "7000,0,0" --v "0,7.5,1"`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dbe5aaaf4832bb9617b8278dc58fe