### PR TITLE
Fix API serialization and add tests

### DIFF
--- a/backend/engine/knowledge.py
+++ b/backend/engine/knowledge.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass, field
+from typing import Any, Dict
+import numpy as np
 
 @dataclass
 class KnowledgeBase:
-    values: dict = field(default_factory=dict)
-    derivations: dict = field(default_factory=dict)
+    values: Dict[str, Any] = field(default_factory=dict)
+    derivations: Dict[str, str] = field(default_factory=dict)
 
     def add(self, key, value, derivation="provided"):
         if key not in self.values:
@@ -17,4 +19,11 @@ class KnowledgeBase:
         return self.values.get(key, default)
 
     def as_dict(self):
-        return self.values
+        def convert(val):
+            if isinstance(val, np.ndarray):
+                return val.tolist()
+            if isinstance(val, np.generic):
+                return val.item()
+            return val
+
+        return {k: convert(v) for k, v in self.values.items()}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,25 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+from backend.main import app
+
+client = TestClient(app)
+
+def test_calculate_vectors():
+    payload = {"r": [7000, 0, 0], "v": [0, 7.5, 1], "mu": 398600.4418}
+    response = client.post("/calculate", json=payload)
+    assert response.status_code == 200
+    data = response.json()["results"]
+    assert "semi_major_axis" in data
+    assert isinstance(data["h_vec"], list)
+
+
+def test_calculate_elements():
+    payload = {"a": 7000, "e": 0.1, "mu": 398600.4418}
+    response = client.post("/calculate", json=payload)
+    assert response.status_code == 200
+    data = response.json()["results"]
+    assert "periapsis" in data
+    assert "apoapsis" in data


### PR DESCRIPTION
## Summary
- convert NumPy types to JSON friendly Python values
- add unit tests for FastAPI `/calculate` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dcb348e68832b9d1ba0237817f0fd