### PR TITLE
Add 3D orbit visualization to frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AstroCalc
 
 
-AstroCalc is an extensible astrodynamics toolkit. A FastAPI backend exposes a calculation engine that infers as many orbital parameters as possible from any known values. A lightweight React frontend is bundled to interact with the API and display visualisations. The engine supports calculations such as inclination, node angles and periapsis/apoapsis distances.
+AstroCalc is an extensible astrodynamics toolkit. A FastAPI backend exposes a calculation engine that infers as many orbital parameters as possible from any known values. A lightweight React frontend is bundled to interact with the API and display visualisations. The engine supports calculations such as inclination, node angles and periapsis/apoapsis distances. The web interface now plots orbits in both 2D and 3D using Plotly and shows results with LaTeX-rendered symbols in a dark themed UI.
 
 
 ## Features
@@ -9,6 +9,7 @@ AstroCalc is an extensible astrodynamics toolkit. A FastAPI backend exposes a ca
 - Vector based computations using NumPy
 - `/calculate` endpoint that accepts position/velocity vectors or orbital elements along with gravitational parameter
 - Returns a dictionary of all derived values including inclination, node angles, periapsis and apoapsis distances
+- React frontend with 2D/3D orbit plots, LaTeX notation and a dark theme
 
 ## Quick Start
 ```bash

--- a/frontend/app.jsx
+++ b/frontend/app.jsx
@@ -7,6 +7,37 @@ function App() {
   });
   const [results, setResults] = React.useState(null);
 
+  const placeholders = {
+    r1: 'r₁ (km)',
+    r2: 'r₂ (km)',
+    r3: 'r₃ (km)',
+    v1: 'v₁ (km/s)',
+    v2: 'v₂ (km/s)',
+    v3: 'v₃ (km/s)',
+    a: 'a (km)',
+    e: 'e',
+    mu: 'μ (km³/s²)'
+  };
+
+  const display = {
+    semi_major_axis: {label: 'a', unit: 'km'},
+    eccentricity: {label: 'e', unit: ''},
+    periapsis: {label: 'q', unit: 'km'},
+    apoapsis: {label: 'Q', unit: 'km'},
+    period: {label: 'T', unit: 's'},
+    mean_motion: {label: 'n', unit: 'rad/s'},
+    inclination: {label: 'i', unit: '\u00b0', convert: v => v * 180 / Math.PI},
+    raan: {label: '\\Omega', unit: '\u00b0', convert: v => v * 180 / Math.PI},
+    argument_of_periapsis: {label: '\\omega', unit: '\u00b0', convert: v => v * 180 / Math.PI},
+    true_anomaly: {label: '\\nu', unit: '\u00b0', convert: v => v * 180 / Math.PI}
+  };
+
+  React.useEffect(() => {
+    if (window.MathJax) {
+      window.MathJax.typesetPromise();
+    }
+  }, [results]);
+
   const handleChange = (e) => {
     setInputs({...inputs, [e.target.name]: e.target.value});
   };
@@ -23,6 +54,7 @@ function App() {
       const res = await axios.post('/calculate', payload);
       setResults(res.data.results);
       drawOrbit(res.data.results);
+      drawOrbit3D(res.data.results);
     } catch(err) {
       alert('Calculation failed');
     }
@@ -37,42 +69,109 @@ function App() {
     const e = data.eccentricity;
     const x = [];
     const y = [];
-    for (let i=0;i<=360;i++) {
+    for (let i = 0; i <= 360; i++) {
       const t = i * Math.PI / 180;
-      const r = a * (1 - e*e) / (1 + e*Math.cos(t));
+      const r = a * (1 - e * e) / (1 + e * Math.cos(t));
       x.push(r * Math.cos(t));
       y.push(r * Math.sin(t));
     }
-    Plotly.newPlot('plot', [{x,y,mode:'lines',name:'Orbit'}], {
-      title: 'Orbit in orbital plane',
-      xaxis: {scaleanchor:'y'},
-      yaxis: {}
-    });
+    Plotly.newPlot(
+      'plot',
+      [{ x, y, mode: 'lines', name: 'Orbit' }],
+      {
+        title: 'Orbit in orbital plane',
+        xaxis: { scaleanchor: 'y', color: '#eee' },
+        yaxis: { color: '#eee' },
+        plot_bgcolor: '#111',
+        paper_bgcolor: '#111',
+        font: { color: '#eee' }
+      }
+    );
+  };
+
+  const drawOrbit3D = (data) => {
+    if (!data.semi_major_axis || data.eccentricity >= 1) {
+      Plotly.purge('plot3d');
+      return;
+    }
+    const a = data.semi_major_axis;
+    const e = data.eccentricity;
+    const inc = data.inclination || 0;
+    const raan = data.raan || 0;
+    const argp = data.argument_of_periapsis || 0;
+
+    const cosO = Math.cos(raan), sinO = Math.sin(raan);
+    const cosi = Math.cos(inc), sini = Math.sin(inc);
+    const cosw = Math.cos(argp), sinw = Math.sin(argp);
+
+    const R11 = cosO * cosw - sinO * sinw * cosi;
+    const R12 = -cosO * sinw - sinO * cosw * cosi;
+    const R21 = sinO * cosw + cosO * sinw * cosi;
+    const R22 = -sinO * sinw + cosO * cosw * cosi;
+    const R31 = sinw * sini;
+    const R32 = cosw * sini;
+
+    const x = [], y = [], z = [];
+    for (let i = 0; i <= 360; i++) {
+      const t = i * Math.PI / 180;
+      const r = a * (1 - e * e) / (1 + e * Math.cos(t));
+      const xp = r * Math.cos(t);
+      const yp = r * Math.sin(t);
+      x.push(R11 * xp + R12 * yp);
+      y.push(R21 * xp + R22 * yp);
+      z.push(R31 * xp + R32 * yp);
+    }
+    Plotly.newPlot(
+      'plot3d',
+      [{ x, y, z, mode: 'lines', type: 'scatter3d', name: 'Orbit' }],
+      {
+        title: 'Orbit in 3D',
+        scene: {
+          xaxis: { title: 'X', color: '#eee', backgroundcolor: '#000' },
+          yaxis: { title: 'Y', color: '#eee', backgroundcolor: '#000' },
+          zaxis: { title: 'Z', color: '#eee', backgroundcolor: '#000' }
+        },
+        plot_bgcolor: '#111',
+        paper_bgcolor: '#111',
+        font: { color: '#eee' }
+      }
+    );
   };
 
   return (
-    <div className="max-w-2xl mx-auto">
+    <div className="max-w-2xl mx-auto text-gray-100">
       <h1 className="text-2xl font-bold mb-4">AstroCalc</h1>
       <div className="grid grid-cols-3 gap-2">
-        {['r1','r2','r3'].map((f,i)=>(
-          <input key={f} name={f} placeholder={'r'+(i+1)} value={inputs[f]} onChange={handleChange} className="border p-2" />
+        {['r1','r2','r3','v1','v2','v3','a','e','mu'].map(f => (
+          <input
+            key={f}
+            name={f}
+            placeholder={placeholders[f]}
+            value={inputs[f]}
+            onChange={handleChange}
+            className="border border-gray-700 bg-gray-800 p-2"
+          />
         ))}
-        {['v1','v2','v3'].map((f,i)=>(
-          <input key={f} name={f} placeholder={'v'+(i+1)} value={inputs[f]} onChange={handleChange} className="border p-2" />
-        ))}
-        <input name="a" placeholder="a" value={inputs.a} onChange={handleChange} className="border p-2" />
-        <input name="e" placeholder="e" value={inputs.e} onChange={handleChange} className="border p-2" />
-        <input name="mu" placeholder="mu" value={inputs.mu} onChange={handleChange} className="border p-2 col-span-3" />
       </div>
-      <button onClick={submit} className="mt-4 px-4 py-2 bg-blue-600 text-white rounded">Calculate</button>
+      <button onClick={submit} className="mt-4 px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded">
+        Calculate
+      </button>
       {results && (
         <div className="mt-4">
           <h2 className="text-xl font-semibold mb-2">Results</h2>
           <div id="plot" className="mb-4" style={{height:'300px'}}></div>
-          <table className="table-auto w-full"><tbody>
-            {Object.entries(results).map(([k,v])=> (
-              <tr key={k}><td className="border px-2 py-1 font-medium">{k}</td><td className="border px-2 py-1">{Array.isArray(v)?v.join(', '):v}</td></tr>
-            ))}
+          <div id="plot3d" className="mb-4" style={{height:'400px'}}></div>
+          <table className="table-auto w-full text-sm"><tbody>
+            {Object.entries(results).map(([k,v]) => {
+              const info = display[k] || {label: k, unit: ''};
+              const val = Array.isArray(v) ? v.join(', ') : (info.convert ? info.convert(v) : v);
+              return (
+                <tr key={k}>
+                  <td className="border border-gray-700 px-2 py-1 font-medium" dangerouslySetInnerHTML={{__html: '$'+info.label+'$'}}></td>
+                  <td className="border border-gray-700 px-2 py-1">{val}{info.unit?` ${info.unit}`:''}</td>
+                </tr>
+              );
+            })}
           </tbody></table>
         </div>
       )}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,8 +10,9 @@
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <script src="https://cdn.plot.ly/plotly-2.25.2.min.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </head>
-<body class="bg-gray-100">
+<body class="bg-gray-900 text-gray-100">
     <div id="root" class="p-4"></div>
     <script type="text/babel" src="app.jsx"></script>
 </body>


### PR DESCRIPTION
## Summary
- plot the orbit in a new 3D view using Plotly
- show both 2D and 3D plots in the results
- document 2D/3D plotting capability in the README
- restyle the frontend in dark mode with LaTeX labels and units

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dcdde47bc832bbfb5aa19e866c1df