### PR TITLE
Add Hohmann transfer calculator

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,21 @@
+# Feature Backlog
+
+This backlog lists planned calculator capabilities and textbook tie-ins for AstroCalc. Each item aligns with an example or exercise sequence from the "Launch Vehicle and Orbital Mechanics" text.
+
+| Calculator feature prompt | Textbook tie‑in |
+|---------------------------|-----------------|
+| Given **r**, **v** in IJK, output **a**, **e**, **i**, **Ω**, **ω**, **ν**. | Chapter 2, sections 2.3–2.5 (elements ⇄ vectors) |
+| Propagate state for Δt via universal‑variable f‑g series; allow elliptical, parabolic, hyperbolic. | Chapter 4, sections 4.2–4.6 |
+| Solve Lambert (Gauss) problem: **r₁**, **r₂**, Δt → **v₁**, **v₂**; support short/long‑way choice. | Chapter 5, sections 5.2 & 5.6 workflow |
+| Compute Hohmann / bi‑elliptic ΔV between two coplanar circular orbits. | Chapter 3, sections 3.3 & 3.4 and transfer tables |
+| Evaluate plane‑change ΔV at any true anomaly or combined Hohmann+plane‑change sequence. | Chapter 3, section 3.4 |
+| Generate ground‑track for user‑defined orbit over N revolutions. | Chapter 2, section 2.15 (ground‑track equations) |
+| Estimate J₂ nodal regression & apsidal rotation rates for a circular LEO. | Chapter 9 perturbation introduction |
+| Patched‑conic Earth‑to‑Moon transfer: give insertion ΔV, perilune radius, TLI epoch sweep. | Chapter 7, sections 7.3–7.5 |
+| Interplanetary pork‑chop plot: compute C₃/ΔV grid for launch window. | Chapter 8, section 8.3 |
+| Sub‑orbital trajectory tool: max‑range, flight‑time, re‑entry impact for given launch site & azimuth. | Chapter 6, sections 6.2–6.4 |
+| Monte‑Carlo launch‑error dispersion showing CEP ellipse on target plane. | Chapter 6, section 6.3 (statistics) |
+| Batch‑process optical angle sets (α, δ) to initial orbit via Gibbs/Laplace. | Chapter 2, sections 2.10–2.12 |
+| Interactive exercise mode: auto‑grade textbook Exercises X.Y (#) with step‑by‑step hints. | End‑of‑chapter exercise lists (e.g. Ch. 2 p. 144, Ch. 4 p. 222) |
+
+These tickets will drive future API endpoints and frontend pages. As each chapter is covered, its corresponding features can be implemented and cross‑referenced here.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ AstroCalc is an extensible astrodynamics toolkit. A FastAPI backend exposes a ca
 - Vector based computations using NumPy
 - `/calculate` endpoint that accepts position/velocity vectors or orbital elements along with gravitational parameter
 - Returns a dictionary of all derived values including inclination, node angles, periapsis and apoapsis distances
-- React frontend with 2D/3D orbit plots, LaTeX notation and a dark theme
+- `/hohmann` endpoint computes transfer \u0394V between two circular orbits
+- React frontend with a calculator menu, 2D/3D orbit plots, LaTeX notation and a dark theme
 
 ## Quick Start
 ```bash

--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 import numpy as np
-from .models import CalculateRequest, CalculateResponse
-from ..engine import engine, constants
+from .models import CalculateRequest, CalculateResponse, HohmannRequest, HohmannResponse
+from ..engine import engine, constants, formulas
 
 router = APIRouter()
 solver = engine.AstroCalc()
@@ -19,3 +19,14 @@ def calculate(req: CalculateRequest):
         knowns["eccentricity"] = req.e
     kb = solver.solve(**knowns)
     return {"results": kb.as_dict()}
+
+
+@router.post("/hohmann", response_model=HohmannResponse)
+def hohmann(req: HohmannRequest):
+    dv1, dv2, total, tof = formulas.hohmann_delta_v(req.r1, req.r2, req.mu)
+    return {
+        "delta_v1": dv1,
+        "delta_v2": dv2,
+        "total_delta_v": total,
+        "transfer_time": tof,
+    }

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -10,3 +10,16 @@ class CalculateRequest(BaseModel):
 
 class CalculateResponse(BaseModel):
     results: dict
+
+
+class HohmannRequest(BaseModel):
+    r1: float = Field(..., description="Initial circular orbit radius in km")
+    r2: float = Field(..., description="Final circular orbit radius in km")
+    mu: float = Field(..., description="Gravitational parameter")
+
+
+class HohmannResponse(BaseModel):
+    delta_v1: float
+    delta_v2: float
+    total_delta_v: float
+    transfer_time: float

--- a/backend/engine/formulas.py
+++ b/backend/engine/formulas.py
@@ -121,3 +121,13 @@ def true_anomaly(e_vec, r, v):
     if np.dot(r, v) < 0:
         nu = 2 * pi - nu
     return nu
+
+
+def hohmann_delta_v(r1, r2, mu):
+    """Return the two burn magnitudes, total \u0394V and transfer time."""
+    dv1 = sqrt(mu / r1) * (sqrt(2 * r2 / (r1 + r2)) - 1)
+    dv2 = sqrt(mu / r2) * (1 - sqrt(2 * r1 / (r1 + r2)))
+    total = abs(dv1) + abs(dv2)
+    a_trans = (r1 + r2) / 2
+    tof = pi * sqrt(a_trans ** 3 / mu)
+    return dv1, dv2, total, tof

--- a/frontend/app.jsx
+++ b/frontend/app.jsx
@@ -1,4 +1,4 @@
-function App() {
+function OrbitCalc({goHome}) {
   const [inputs, setInputs] = React.useState({
     r1: '', r2: '', r3: '',
     v1: '', v2: '', v3: '',
@@ -9,284 +9,172 @@ function App() {
   const [tab, setTab] = React.useState('visual');
 
   const placeholders = {
-    r1: 'r₁ (km)',
-    r2: 'r₂ (km)',
-    r3: 'r₃ (km)',
-    v1: 'v₁ (km/s)',
-    v2: 'v₂ (km/s)',
-    v3: 'v₃ (km/s)',
-    a: 'a (km)',
-    e: 'e',
-    mu: 'μ (km³/s²)'
+    r1: 'r₁ (km)', r2: 'r₂ (km)', r3: 'r₃ (km)',
+    v1: 'v₁ (km/s)', v2: 'v₂ (km/s)', v3: 'v₃ (km/s)',
+    a: 'a (km)', e: 'e', mu: 'μ (km³/s²)'
   };
-
   const display = {
-    semi_major_axis: {label: 'a', unit: 'km'},
-    eccentricity: {label: 'e', unit: ''},
-    periapsis: {label: 'q', unit: 'km'},
-    apoapsis: {label: 'Q', unit: 'km'},
-    period: {label: 'T', unit: 's'},
-    mean_motion: {label: 'n', unit: 'rad/s'},
-    inclination: {label: 'i', unit: '\u00b0', convert: v => v * 180 / Math.PI},
-    raan: {label: '\\Omega', unit: '\u00b0', convert: v => v * 180 / Math.PI},
-    argument_of_periapsis: {label: '\\omega', unit: '\u00b0', convert: v => v * 180 / Math.PI},
-    true_anomaly: {label: '\\nu', unit: '\u00b0', convert: v => v * 180 / Math.PI}
+    semi_major_axis: {label:'a',unit:'km'}, eccentricity:{label:'e',unit:''},
+    periapsis:{label:'q',unit:'km'}, apoapsis:{label:'Q',unit:'km'},
+    period:{label:'T',unit:'s'}, mean_motion:{label:'n',unit:'rad/s'},
+    inclination:{label:'i',unit:'\u00b0',convert:v=>v*180/Math.PI},
+    raan:{label:'\\Omega',unit:'\u00b0',convert:v=>v*180/Math.PI},
+    argument_of_periapsis:{label:'\\omega',unit:'\u00b0',convert:v=>v*180/Math.PI},
+    true_anomaly:{label:'\\nu',unit:'\u00b0',convert:v=>v*180/Math.PI}
   };
 
-  React.useEffect(() => {
-    if (window.MathJax) {
-      window.MathJax.typesetPromise();
-    }
-  }, [results, tab]);
+  React.useEffect(() => { if(window.MathJax) window.MathJax.typesetPromise(); }, [results, tab]);
 
-  const handleChange = (e) => {
-    setInputs({...inputs, [e.target.name]: e.target.value});
-  };
+  const handleChange = (e) => setInputs({...inputs,[e.target.name]:e.target.value});
 
   const submit = async () => {
     const payload = { mu: parseFloat(inputs.mu) };
-    const r = [inputs.r1, inputs.r2, inputs.r3].map(Number);
-    if (r.some(n => !isNaN(n))) payload.r = r;
-    const v = [inputs.v1, inputs.v2, inputs.v3].map(Number);
-    if (v.some(n => !isNaN(n))) payload.v = v;
-    if (inputs.a) payload.a = parseFloat(inputs.a);
-    if (inputs.e) payload.e = parseFloat(inputs.e);
+    const r = [inputs.r1,inputs.r2,inputs.r3].map(Number);
+    if(r.some(n => !isNaN(n))) payload.r = r;
+    const v = [inputs.v1,inputs.v2,inputs.v3].map(Number);
+    if(v.some(n => !isNaN(n))) payload.v = v;
+    if(inputs.a) payload.a = parseFloat(inputs.a);
+    if(inputs.e) payload.e = parseFloat(inputs.e);
     try {
       const res = await axios.post('/calculate', payload);
       setResults(res.data.results);
       drawOrbit(res.data.results);
       drawOrbit3D(res.data.results);
-    } catch(err) {
-      alert('Calculation failed');
-    }
+    } catch(err){ alert('Calculation failed'); }
   };
 
   const drawOrbit = (data) => {
-    if (!data.semi_major_axis || data.eccentricity >= 1) {
-      Plotly.purge('plot');
-      return;
-    }
-    const a = data.semi_major_axis;
-    const e = data.eccentricity;
-    const x = [];
-    const y = [];
-    for (let i = 0; i <= 360; i++) {
-      const t = i * Math.PI / 180;
-      const r = a * (1 - e * e) / (1 + e * Math.cos(t));
-      x.push(r * Math.cos(t));
-      y.push(r * Math.sin(t));
-    }
-    const traces = [{ x, y, mode: 'lines', name: 'Orbit' }];
-    if (data.r) {
-      traces.push({ x: [0, data.r[0]], y: [0, data.r[1]], mode: 'lines+markers', name: 'r' });
-    }
-    if (data.v && data.r) {
-      const scale = a * 0.1;
-      const vx = data.r[0] + data.v[0] * scale;
-      const vy = data.r[1] + data.v[1] * scale;
-      traces.push({ x: [data.r[0], vx], y: [data.r[1], vy], mode: 'lines+markers', name: 'v' });
-    }
-    Plotly.newPlot(
-      'plot',
-      traces,
-      {
-        title: 'Orbit in orbital plane',
-        xaxis: { scaleanchor: 'y', color: '#eee' },
-        yaxis: { color: '#eee' },
-        plot_bgcolor: '#111',
-        paper_bgcolor: '#111',
-        font: { color: '#eee' }
-      }
-    );
+    if(!data.semi_major_axis || data.eccentricity >= 1){ Plotly.purge('plot'); return; }
+    const a=data.semi_major_axis,e=data.eccentricity;
+    const x=[],y=[];
+    for(let i=0;i<=360;i++){ const t=i*Math.PI/180; const r=a*(1-e*e)/(1+e*Math.cos(t)); x.push(r*Math.cos(t)); y.push(r*Math.sin(t)); }
+    const traces=[{x,y,mode:'lines',name:'Orbit'}];
+    if(data.r) traces.push({x:[0,data.r[0]],y:[0,data.r[1]],mode:'lines+markers',name:'r'});
+    if(data.v&&data.r){ const scale=a*0.1; traces.push({x:[data.r[0],data.r[0]+data.v[0]*scale],y:[data.r[1],data.r[1]+data.v[1]*scale],mode:'lines+markers',name:'v'}); }
+    Plotly.newPlot('plot',traces,{title:'Orbit in orbital plane',xaxis:{scaleanchor:'y',color:'#eee'},yaxis:{color:'#eee'},plot_bgcolor:'#111',paper_bgcolor:'#111',font:{color:'#eee'}});
   };
 
   const drawOrbit3D = (data) => {
-    if (!data.semi_major_axis || data.eccentricity >= 1) {
-      Plotly.purge('plot3d');
-      return;
-    }
-    const EARTH_RADIUS = 6378.137;
-    const a = data.semi_major_axis;
-    const e = data.eccentricity;
-    const inc = data.inclination || 0;
-    const raan = data.raan || 0;
-    const argp = data.argument_of_periapsis || 0;
-
-    const cosO = Math.cos(raan), sinO = Math.sin(raan);
-    const cosi = Math.cos(inc), sini = Math.sin(inc);
-    const cosw = Math.cos(argp), sinw = Math.sin(argp);
-
-    const R11 = cosO * cosw - sinO * sinw * cosi;
-    const R12 = -cosO * sinw - sinO * cosw * cosi;
-    const R21 = sinO * cosw + cosO * sinw * cosi;
-    const R22 = -sinO * sinw + cosO * cosw * cosi;
-    const R31 = sinw * sini;
-    const R32 = cosw * sini;
-
-    const x = [], y = [], z = [];
-    for (let i = 0; i <= 360; i++) {
-      const t = i * Math.PI / 180;
-      const r = a * (1 - e * e) / (1 + e * Math.cos(t));
-      const xp = r * Math.cos(t);
-      const yp = r * Math.sin(t);
-      x.push(R11 * xp + R12 * yp);
-      y.push(R21 * xp + R22 * yp);
-      z.push(R31 * xp + R32 * yp);
-    }
-
-    // Earth sphere
-    const latSteps = 20, lonSteps = 20;
-    const ex = [], ey = [], ez = [];
-    for (let i = 0; i <= latSteps; i++) {
-      const theta = i * Math.PI / latSteps;
-      const rowX = [], rowY = [], rowZ = [];
-      for (let j = 0; j <= lonSteps; j++) {
-        const phi = j * 2 * Math.PI / lonSteps;
-        rowX.push(EARTH_RADIUS * Math.sin(theta) * Math.cos(phi));
-        rowY.push(EARTH_RADIUS * Math.sin(theta) * Math.sin(phi));
-        rowZ.push(EARTH_RADIUS * Math.cos(theta));
-      }
-      ex.push(rowX); ey.push(rowY); ez.push(rowZ);
-    }
-
-    const traces = [
-      { x: ex, y: ey, z: ez, opacity: 0.5, showscale: false, colorscale: 'Blues', type: 'surface', name: 'Earth' },
-      { x, y, z, mode: 'lines', type: 'scatter3d', name: 'Orbit' }
-    ];
-
-    if (data.r) {
-      traces.push({ x: [0, data.r[0]], y: [0, data.r[1]], z: [0, data.r[2]], mode: 'lines+markers', type: 'scatter3d', name: 'r' });
-    }
-    if (data.v && data.r) {
-      const scale = a * 0.1;
-      const vx = data.r[0] + data.v[0] * scale;
-      const vy = data.r[1] + data.v[1] * scale;
-      const vz = data.r[2] + data.v[2] * scale;
-      traces.push({ x: [data.r[0], vx], y: [data.r[1], vy], z: [data.r[2], vz], mode: 'lines+markers', type: 'scatter3d', name: 'v' });
-    }
-
-    const rotate = (vec, axis, angle) => {
-      const [u, v, w] = axis;
-      const [x0, y0, z0] = vec;
-      const cosA = Math.cos(angle), sinA = Math.sin(angle);
-      const dot = u * x0 + v * y0 + w * z0;
-      return [
-        u * dot * (1 - cosA) + x0 * cosA + (-w * y0 + v * z0) * sinA,
-        v * dot * (1 - cosA) + y0 * cosA + (w * x0 - u * z0) * sinA,
-        w * dot * (1 - cosA) + z0 * cosA + (-v * x0 + u * y0) * sinA,
-      ];
-    };
-
-    const planeSize = a * 1.2;
-    const nodeDir = [Math.cos(raan), Math.sin(raan), 0];
-    const normal = [Math.sin(inc) * Math.sin(raan), -Math.sin(inc) * Math.cos(raan), Math.cos(inc)];
-    const periDir = [R11, R21, R31];
-    const perpDir = [-cosO * sinw - sinO * cosw * cosi, -sinO * sinw + cosO * cosw * cosi, cosw * sini];
-
-    // planes
-    traces.push({ x: [-planeSize, planeSize], y: [0, 0], z: [0, 0], mode: 'lines', type: 'scatter3d', line: {color:'rgba(200,200,200,0.3)'}, name: 'Equatorial plane' });
-    traces.push({ x: [0, 0], y: [-planeSize, planeSize], z: [0, 0], mode: 'lines', type: 'scatter3d', line: {color:'rgba(200,200,200,0.3)'}, showlegend: false });
-    traces.push({ x: [-planeSize*periDir[0], planeSize*periDir[0]], y: [-planeSize*periDir[1], planeSize*periDir[1]], z: [-planeSize*periDir[2], planeSize*periDir[2]], mode: 'lines', type: 'scatter3d', line:{color:'rgba(0,150,0,0.3)'}, name:'Orbital plane' });
-    traces.push({ x: [-planeSize*perpDir[0], planeSize*perpDir[0]], y: [-planeSize*perpDir[1], planeSize*perpDir[1]], z: [-planeSize*perpDir[2], planeSize*perpDir[2]], mode: 'lines', type: 'scatter3d', line:{color:'rgba(0,150,0,0.3)'}, showlegend:false });
-
-    // vectors
-    traces.push({ x:[0,nodeDir[0]*planeSize], y:[0,nodeDir[1]*planeSize], z:[0,nodeDir[2]*planeSize], mode:'lines', type:'scatter3d', line:{color:'yellow'}, name:'Ascending node' });
-    traces.push({ x:[0,periDir[0]*planeSize], y:[0,periDir[1]*planeSize], z:[0,periDir[2]*planeSize], mode:'lines', type:'scatter3d', line:{color:'cyan'}, name:'Periapsis' });
-
-    // arcs
-    const arcSteps = 30; const rArc = EARTH_RADIUS * 1.5;
-    const arcX = [], arcY = [], arcZ = [];
-    for(let i=0;i<=arcSteps;i++){
-      const t = (raan*i)/arcSteps;
-      arcX.push(rArc*Math.cos(t));
-      arcY.push(rArc*Math.sin(t));
-      arcZ.push(0);
-    }
-    traces.push({x:arcX, y:arcY, z:arcZ, mode:'lines', type:'scatter3d', line:{color:'yellow'}, name:'Ω'});
-
-    const arcX2=[], arcY2=[], arcZ2=[];
-    for(let i=0;i<=arcSteps;i++){
-      const t = (argp*i)/arcSteps;
-      const p = rotate(nodeDir, normal, t);
-      arcX2.push(p[0]*rArc); arcY2.push(p[1]*rArc); arcZ2.push(p[2]*rArc);
-    }
-    traces.push({x:arcX2, y:arcY2, z:arcZ2, mode:'lines', type:'scatter3d', line:{color:'cyan'}, name:'ω'});
-
-    const arcX3=[], arcY3=[], arcZ3=[];
-    for(let i=0;i<=arcSteps;i++){
-      const t = (inc*i)/arcSteps;
-      const p = rotate([0,0,1], nodeDir, t);
-      arcX3.push(p[0]*rArc); arcY3.push(p[1]*rArc); arcZ3.push(p[2]*rArc);
-    }
-    traces.push({x:arcX3, y:arcY3, z:arcZ3, mode:'lines', type:'scatter3d', line:{color:'magenta'}, name:'i'});
-
-    Plotly.newPlot(
-      'plot3d',
-      traces,
-      {
-        title: 'Orbit in 3D',
-        scene: {
-          xaxis: { title: 'X', color: '#eee', backgroundcolor: '#000' },
-          yaxis: { title: 'Y', color: '#eee', backgroundcolor: '#000' },
-          zaxis: { title: 'Z', color: '#eee', backgroundcolor: '#000' }
-        },
-        plot_bgcolor: '#111',
-        paper_bgcolor: '#111',
-        font: { color: '#eee' }
-      }
-    );
+    if(!data.semi_major_axis || data.eccentricity>=1){ Plotly.purge('plot3d'); return; }
+    const EARTH_RADIUS=6378.137; const a=data.semi_major_axis,e=data.eccentricity; const inc=data.inclination||0; const raan=data.raan||0; const argp=data.argument_of_periapsis||0;
+    const cosO=Math.cos(raan),sinO=Math.sin(raan); const cosi=Math.cos(inc),sini=Math.sin(inc); const cosw=Math.cos(argp),sinw=Math.sin(argp);
+    const R11=cosO*cosw - sinO*sinw*cosi, R12=-cosO*sinw - sinO*cosw*cosi; const R21=sinO*cosw + cosO*sinw*cosi, R22=-sinO*sinw + cosO*cosw*cosi; const R31=sinw*sini, R32=cosw*sini;
+    const x=[],y=[],z=[]; for(let i=0;i<=360;i++){ const t=i*Math.PI/180; const r=a*(1-e*e)/(1+e*Math.cos(t)); const xp=r*Math.cos(t), yp=r*Math.sin(t); x.push(R11*xp+R12*yp); y.push(R21*xp+R22*yp); z.push(R31*xp+R32*yp); }
+    const latSteps=20, lonSteps=20, ex=[],ey=[],ez=[]; for(let i=0;i<=latSteps;i++){ const theta=i*Math.PI/latSteps; const rowX=[],rowY=[],rowZ=[]; for(let j=0;j<=lonSteps;j++){ const phi=j*2*Math.PI/lonSteps; rowX.push(EARTH_RADIUS*Math.sin(theta)*Math.cos(phi)); rowY.push(EARTH_RADIUS*Math.sin(theta)*Math.sin(phi)); rowZ.push(EARTH_RADIUS*Math.cos(theta)); } ex.push(rowX); ey.push(rowY); ez.push(rowZ); }
+    const traces=[{x:ex,y:ey,z:ez,opacity:0.5,showscale:false,colorscale:'Blues',type:'surface',name:'Earth'},{x,y,z,mode:'lines',type:'scatter3d',name:'Orbit'}];
+    if(data.r) traces.push({x:[0,data.r[0]],y:[0,data.r[1]],z:[0,data.r[2]],mode:'lines+markers',type:'scatter3d',name:'r'});
+    if(data.v&&data.r){ const scale=a*0.1; traces.push({x:[data.r[0],data.r[0]+data.v[0]*scale],y:[data.r[1],data.r[1]+data.v[1]*scale],z:[data.r[2],data.r[2]+data.v[2]*scale],mode:'lines+markers',type:'scatter3d',name:'v'}); }
+    Plotly.newPlot('plot3d',traces,{title:'Orbit in 3D',scene:{xaxis:{title:'X',color:'#eee',backgroundcolor:'#000'},yaxis:{title:'Y',color:'#eee',backgroundcolor:'#000'},zaxis:{title:'Z',color:'#eee',backgroundcolor:'#000'}},plot_bgcolor:'#111',paper_bgcolor:'#111',font:{color:'#eee'}});
   };
 
   return (
     <div className="max-w-2xl mx-auto text-gray-100">
-      <h1 className="text-2xl font-bold mb-4">AstroCalc</h1>
+      <button onClick={goHome} className="mb-2 text-blue-400">&larr; Home</button>
+      <h1 className="text-2xl font-bold mb-4">Orbit Elements</h1>
       <div className="grid grid-cols-3 gap-2">
         {['r1','r2','r3','v1','v2','v3','a','e','mu'].map(f => (
-          <input
-            key={f}
-            name={f}
-            placeholder={placeholders[f]}
-            value={inputs[f]}
-            onChange={handleChange}
-            className="border border-gray-700 bg-gray-800 p-2"
-          />
+          <input key={f} name={f} placeholder={placeholders[f]} value={inputs[f]} onChange={handleChange} className="border border-gray-700 bg-gray-800 p-2" />
         ))}
       </div>
-      <button onClick={submit} className="mt-4 px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded">
-        Calculate
-      </button>
+      <button onClick={submit} className="mt-4 px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded">Calculate</button>
       {results && (
         <div className="mt-4">
           <h2 className="text-xl font-semibold mb-2">Results</h2>
           <div className="flex space-x-2 mb-4">
-            <button onClick={() => setTab('visual')} className={tab==='visual'?'bg-blue-600 text-white px-3 py-1 rounded':'bg-gray-700 px-3 py-1 rounded'}>Visuals</button>
-            <button onClick={() => setTab('table')} className={tab==='table'?'bg-blue-600 text-white px-3 py-1 rounded':'bg-gray-700 px-3 py-1 rounded'}>Table</button>
+            <button onClick={()=>setTab('visual')} className={tab==='visual'?'bg-blue-600 text-white px-3 py-1 rounded':'bg-gray-700 px-3 py-1 rounded'}>Visuals</button>
+            <button onClick={()=>setTab('table')} className={tab==='table'?'bg-blue-600 text-white px-3 py-1 rounded':'bg-gray-700 px-3 py-1 rounded'}>Table</button>
           </div>
-          {tab==='visual' && (
-            <>
-              <div id="plot" className="mb-4" style={{height:'300px'}}></div>
-              <div id="plot3d" className="mb-4" style={{height:'400px'}}></div>
-              <p className="text-sm">Visualization showing current radius and velocity vectors at true anomaly position.</p>
-            </>
-          )}
+          {tab==='visual' && (<>
+            <div id="plot" className="mb-4" style={{height:'300px'}}></div>
+            <div id="plot3d" className="mb-4" style={{height:'400px'}}></div>
+            <p className="text-sm">Visualization showing radius and velocity vectors.</p>
+          </>)}
           {tab==='table' && (
             <table className="table-auto w-full text-sm"><tbody>
-              {Object.entries(results).map(([k,v]) => {
-                const info = display[k] || {label: k, unit: ''};
-                const val = Array.isArray(v) ? v.join(', ') : (info.convert ? info.convert(v) : v);
-                return (
-                  <tr key={k}>
-                    <td className="border border-gray-700 px-2 py-1 font-medium" dangerouslySetInnerHTML={{__html: '$'+info.label+'$'}}></td>
-                    <td className="border border-gray-700 px-2 py-1">{val}{info.unit?` ${info.unit}`:''}</td>
-                  </tr>
-                );
-              })}
+              {Object.entries(results).map(([k,v]) => { const info=display[k]||{label:k,unit:''}; const val=Array.isArray(v)?v.join(', '):(info.convert?info.convert(v):v); return (
+                <tr key={k}><td className="border border-gray-700 px-2 py-1 font-medium" dangerouslySetInnerHTML={{__html:'$'+info.label+'$'}}></td><td className="border border-gray-700 px-2 py-1">{val}{info.unit?` ${info.unit}`:''}</td></tr>
+              ); })}
             </tbody></table>
           )}
         </div>
       )}
     </div>
   );
+}
+
+function HohmannCalc({goHome}) {
+  const [r1,setR1] = React.useState('');
+  const [r2,setR2] = React.useState('');
+  const [mu,setMu] = React.useState(398600.4418);
+  const [res,setRes] = React.useState(null);
+
+  React.useEffect(() => { if(window.MathJax) window.MathJax.typesetPromise(); }, [res]);
+
+  const submit = async () => {
+    try {
+      const payload={r1:parseFloat(r1),r2:parseFloat(r2),mu:parseFloat(mu)};
+      const resp=await axios.post('/hohmann',payload);
+      setRes(resp.data);
+      draw(resp.data);
+    } catch(e){ alert('Calculation failed'); }
+  };
+
+  const draw = (data) => {
+    const r1v=parseFloat(r1), r2v=parseFloat(r2);
+    if(!r1v || !r2v){ Plotly.purge('hohmann'); return; }
+    const a=(r1v+r2v)/2; const e=(r2v-r1v)/(r1v+r2v);
+    const circ=(r)=>{const x=[],y=[]; for(let i=0;i<=360;i++){const t=i*Math.PI/180; x.push(r*Math.cos(t)); y.push(r*Math.sin(t)); } return {x,y};};
+    const t1=circ(r1v), t2=circ(r2v);
+    const xe=[], ye=[]; for(let i=0;i<=180;i++){ const t=i*Math.PI/180; const r=a*(1-e*e)/(1+e*Math.cos(t)); xe.push(r*Math.cos(t)); ye.push(r*Math.sin(t)); }
+    Plotly.newPlot('hohmann',[
+      {...t1,mode:'lines',name:'Initial'},
+      {...t2,mode:'lines',name:'Final'},
+      {x:xe,y:ye,mode:'lines',name:'Transfer'}],
+      {title:'Hohmann Transfer',xaxis:{scaleanchor:'y',color:'#eee'},yaxis:{color:'#eee'},plot_bgcolor:'#111',paper_bgcolor:'#111',font:{color:'#eee'}});
+  };
+
+  return (
+    <div className="max-w-md mx-auto text-gray-100">
+      <button onClick={goHome} className="mb-2 text-blue-400">&larr; Home</button>
+      <h1 className="text-2xl font-bold mb-4">Hohmann Transfer</h1>
+      <div className="grid grid-cols-3 gap-2">
+        <input placeholder="r₁ (km)" value={r1} onChange={e=>setR1(e.target.value)} className="border border-gray-700 bg-gray-800 p-2" />
+        <input placeholder="r₂ (km)" value={r2} onChange={e=>setR2(e.target.value)} className="border border-gray-700 bg-gray-800 p-2" />
+        <input placeholder="μ (km³/s²)" value={mu} onChange={e=>setMu(e.target.value)} className="border border-gray-700 bg-gray-800 p-2" />
+      </div>
+      <button onClick={submit} className="mt-4 px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded">Calculate</button>
+      {res && (
+        <div className="mt-4">
+          <div id="hohmann" className="mb-4" style={{height:'300px'}}></div>
+          <table className="table-auto w-full text-sm"><tbody>
+            <tr><td className="border px-2 py-1">ΔV₁</td><td className="border px-2 py-1">{res.delta_v1.toFixed(3)} km/s</td></tr>
+            <tr><td className="border px-2 py-1">ΔV₂</td><td className="border px-2 py-1">{res.delta_v2.toFixed(3)} km/s</td></tr>
+            <tr><td className="border px-2 py-1">Total ΔV</td><td className="border px-2 py-1">{res.total_delta_v.toFixed(3)} km/s</td></tr>
+            <tr><td className="border px-2 py-1">Transfer time</td><td className="border px-2 py-1">{res.transfer_time.toFixed(1)} s</td></tr>
+          </tbody></table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Menu({setPage}){
+  return (
+    <div className="max-w-md mx-auto text-gray-100">
+      <h1 className="text-2xl font-bold mb-4">AstroCalc</h1>
+      <div className="space-y-2">
+        <button onClick={()=>setPage('orbit')} className="block w-full px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded">Orbit Elements</button>
+        <button onClick={()=>setPage('hohmann')} className="block w-full px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded">Hohmann Transfer</button>
+      </div>
+    </div>
+  );
+}
+
+function App(){
+  const [page,setPage] = React.useState('menu');
+  if(page==='orbit') return <OrbitCalc goHome={()=>setPage('menu')}/>;
+  if(page==='hohmann') return <HohmannCalc goHome={()=>setPage('menu')}/>;
+  return <Menu setPage={setPage}/>;
 }
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,3 +23,12 @@ def test_calculate_elements():
     data = response.json()["results"]
     assert "periapsis" in data
     assert "apoapsis" in data
+
+
+def test_hohmann_endpoint():
+    payload = {"r1": 7000, "r2": 10000, "mu": 398600.4418}
+    response = client.post("/hohmann", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert "total_delta_v" in data
+    assert data["total_delta_v"] > 0

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -6,6 +6,7 @@ import numpy as np
 from pytest import approx
 from backend.engine.engine import AstroCalc
 from backend.engine.constants import EARTH_MU, EARTH_RADIUS
+from backend.engine import formulas
 
 
 def test_basic_solve():
@@ -29,3 +30,11 @@ def test_with_elements():
 
 def test_constants_exposed():
     assert EARTH_RADIUS > 6000
+
+
+def test_hohmann_formula():
+    dv1, dv2, total, tof = formulas.hohmann_delta_v(7000, 10000, EARTH_MU)
+    assert dv1 > 0
+    assert dv2 > 0
+    assert total > abs(dv1)
+    assert tof > 0


### PR DESCRIPTION
## Summary
- implement Hohmann ΔV formula in engine
- expose `/hohmann` endpoint with request/response models
- update frontend to provide a simple calculator menu
- add new React component for Hohmann transfer with plot and result table
- expand README and tests
- add backlog of textbook-aligned calculator tickets

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e6a99d910832bac3303f88dbee4e7